### PR TITLE
Fix 'rpc error: code = InvalidArgument desc = Invalid parent id!' err…

### DIFF
--- a/exporter/trace/trace_proto.go
+++ b/exporter/trace/trace_proto.go
@@ -84,7 +84,7 @@ func protoFromSpanData(s *export.SpanData, projectID string) *tracepb.Span {
 		SameProcessAsParentSpan: &wrapperspb.BoolValue{Value: !s.HasRemoteParent},
 	}
 	if s.ParentSpanID != s.SpanContext.SpanID && s.ParentSpanID.IsValid() {
-		sp.ParentSpanId = fmt.Sprintf("%.16x", s.ParentSpanID)
+		sp.ParentSpanId = s.ParentSpanID.String()
 	}
 	if s.StatusCode != codes.OK {
 		sp.Status = &statuspb.Status{Code: int32(s.StatusCode)}


### PR DESCRIPTION
…ors.

The parent span ID was being formatted incorrectly, which meant all
spans except the root span were rejected by the GCP tracing API.

If clients did not have error logging hooked up to WithOnError, this
would cause child spans to be silently dropped.

The documentation says the parent span ID should be formatted as a
64-bit integer encoded as a string, but appears to accept the
hexadecimal format returned by SpanID.String().